### PR TITLE
Made string search for class line more strict

### DIFF
--- a/src/Philwinkle/CoreHack.php
+++ b/src/Philwinkle/CoreHack.php
@@ -42,10 +42,13 @@ class CoreHack
                 $this->file->seek($line);
 
                 $matches = [];
-                if(stristr($this->file->current(), 'class')){
+                if(stristr($this->file->current(), 'class') 
+                  && preg_match('/^(abstract\s+)?(final\s+)?class/', $this->file->current())
+                ) {
                     preg_match_all('/class\s+(.*?)\s+/', $this->file->current(), $matches);
                     $className = $matches[1][0];
                     $this->className = $className;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
This was just a quick attempt to make this work for me. I think the logic probably needs exclude the search to app/code and lib, as well as only php files since this is only looking for core hacks to class files.
